### PR TITLE
Make sparql statement more future-proof

### DIFF
--- a/sparql/human-pr-mapping.sparql
+++ b/sparql/human-pr-mapping.sparql
@@ -1,12 +1,4 @@
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
-PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX owl: <http://www.w3.org/2002/07/owl#>
-PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
-PREFIX obo: <http://purl.obolibrary.org/obo_>
 PREFIX PR: <http://purl.obolibrary.org/obo/PR_>
-PREFIX CHEBI: <http://purl.obolibrary.org/obo/CHEBI_>
-PREFIX COB: <http://purl.obolibrary.org/obo/COB_>
 PREFIX subClassOf: <http://www.w3.org/2000/01/rdf-schema#subClassOf>
 PREFIX label: <http://www.w3.org/2000/01/rdf-schema#label>
 PREFIX semapv: <ttps://w3id.org/semapv/vocab/>
@@ -14,7 +6,7 @@ PREFIX semapv: <ttps://w3id.org/semapv/vocab/>
 ######################################
 ## Subclasses of
 ## PR:000029067 Homo sapiens protein
-## PR:000050567 protein-containing material entity
+## PR:000000001 protein
 ######################################
 
 CONSTRUCT
@@ -26,7 +18,7 @@ WHERE {
        ?sub subClassOf:* PR:000029067 ; # Homo sapiens protein
             subClassOf: ?super ;
              label: ?label .
-       ?super subClassOf:* PR:000050567 ; # protein-containing material entity
+       ?super subClassOf:* PR:000000001 ; # protein-containing material entity
               label: ?slabel .
 FILTER (?sub != ?super)
 FILTER ( LCASE(STR(?slabel)) = STRBEFORE( LCASE(STR(?label)), " (human)" ) ) # match classes based on label; this is slow but critical

--- a/sparql/human-pr-mapping.sparql
+++ b/sparql/human-pr-mapping.sparql
@@ -18,7 +18,7 @@ WHERE {
        ?sub subClassOf:* PR:000029067 ; # Homo sapiens protein
             subClassOf: ?super ;
              label: ?label .
-       ?super subClassOf:* PR:000000001 ; # protein-containing material entity
+       ?super subClassOf:* PR:000000001 ; # protein
               label: ?slabel .
 FILTER (?sub != ?super)
 FILTER ( LCASE(STR(?slabel)) = STRBEFORE( LCASE(STR(?label)), " (human)" ) ) # match classes based on label; this is slow but critical


### PR DESCRIPTION
Replace soon-to-be obsolete [PR:000050567 protein-containing material entity](http://purl.obolibrary.org/obo/PR_000050567) with [PR:000000001 protein](http://purl.obolibrary.org/obo/PR_000000001) in the SPARQL statement.

I have tested the new version and it works fine.