### PR TITLE
Force refresh the mirrored PRO under MIR=true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,6 @@ human-pr-mapping.ttl: mirror/pr-mapping-filtered.owl
 mirror/pr-pre.owl: mirror/pr.owl human-pr-mapping.ttl
 	$(ROBOT) merge -i mirror/pr.owl -i human-pr-mapping.ttl -o $@
 
-#build/%.db: src/scripts/prefixes.sql mirror/%.owl.gz | build/rdftab
-#	rm -rf $@
-#	sqlite3 $@ < $<
-#	zcat < $(word 2,$^) | ./build/rdftab $@
-#	sqlite3 $@ "CREATE INDEX idx_stanza ON statements (stanza);"
-#	sqlite3 $@ "ANALYZE;"
-
 pr_slim.owl: mirror/pr-pre.owl seed.txt
 	$(ROBOT) extract -i $< -T seed.txt --force true --copy-ontology-annotations true --individuals include --method BOT \
 		remove --term MOD:00693 \
@@ -53,7 +46,7 @@ pr_slim.owl: mirror/pr-pre.owl seed.txt
 
 pr_slim.obo: pr_slim.owl
 	$(ROBOT) convert --input $< --check false -f obo -o $@.tmp.obo && grep -v ^owl-axioms $@.tmp.obo > $@ && rm $@.tmp.obo
-.PRECIOUS: pr_slim.obo.obo
+.PRECIOUS: pr_slim.obo
 
 all: pr_slim.owl pr_slim.obo
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CLEAN_FILES=                pr.owl.gz pr.owl pr-mapping-filtered.owl
 ifeq ($(MIR),true)
 mirror/pr.owl.gz: clean
 	curl -L $(URIBASE)/pr.owl.gz --create-dirs -o $@ --retry 4 --max-time 200
-.PRECIOUS: mirror/pr.owl
+.PRECIOUS: mirror/pr.owl.gz
 endif
 
 mirror/pr.owl: mirror/pr.owl.gz

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,21 @@ VERSION=                    $(TODAY)
 ANNOTATE_ONTOLOGY_VERSION = annotate -V $(ONTBASE)/releases/$(VERSION)/$@ --annotation owl:versionInfo $(VERSION)
 
 MIR=                        true
+CLEAN_FILES=                pr.owl.gz pr.owl pr-mapping-filtered.owl
 
-mirror/pr.owl:
-	if [ $(MIR) = true ]; then curl -L $(URIBASE)/pr.owl.gz --create-dirs -o mirror/pr.owl.gz --retry 4 --max-time 200 && $(ROBOT) convert -i mirror/pr.owl.gz -o $@.tmp.owl && mv $@.tmp.owl $@; fi
+ifeq ($(MIR),true)
+mirror/pr.owl.gz: clean
+	curl -L $(URIBASE)/pr.owl.gz --create-dirs -o $@ --retry 4 --max-time 200
+.PRECIOUS: mirror/pr.owl
+endif
+
+mirror/pr.owl: mirror/pr.owl.gz
+	$(ROBOT) convert -i $< -o $@
 .PRECIOUS: mirror/pr.owl
 
-mirror/pr.owl.gz:
-	if [ $(MIR) = true ]; then curl -L $(URIBASE)/pr.owl.gz --create-dirs -o $@ --retry 4 --max-time 200; fi
-.PRECIOUS: mirror/pr.owl.gz
+clean:
+	rm -f $(foreach file, $(CLEAN_FILES), mirror/$(file))
+.PHONY: clean
 
 # This goal is only for extracting the mappings. We take all PRO terms in the seed
 # Then get their parents and children, and then run the mappings query.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,18 @@
 # Adding terms to PRO slim 
 
-1. Clone the PRo slim to your Github
+1. Clone the PRO slim to your Github
 2. Add the PR ID to seed.txt in the correct order. (To programmatically sort seed.txt, you can run on the terminal, if you use macOS, `cat seed.txt | sort | uniq > seed.tmp.txt && mv seed.tmp.txt seed.txt`)
 3. On your terminal (assuming your diretory is on the repo) run: 'sh odk.sh make all'
 4. Make a pull request as usual
+
+If you are updating the PRO slim several times out of the same cloned
+repository, be aware that running the `sh odk.sh make all` command (step
+3 above) will always forcefully download the most recent version of PRO.
+If that is not desired (e.g. if you are sure that you have a recent
+enough version, maybe because you last run the command earlier on the
+same day), you may call the command as `sh odk.sh make all MIR=false`.
+You may only do that if you are the last person to have updated the
+slim! If the last update was made by someone else, you _must_ ensure
+that you are using a version of PRO that is at least as recent as the
+one used for the last update, and the easiest way to ensure that is to
+always get the latest version (which is the default behaviour).


### PR DESCRIPTION
The `MIR` variable in the Makefile does not really work as people may expect (especially people familiar with ODK workflows): setting it to `false` disables the downloading of the latest version of PRO, but setting it to `true` (which is its default value) does _not_ cause the mirror to be refreshed if it already exists -- it only causes the mirror to be created once if it does not already exists.

This PR amends the behaviour around the `MIR` variable so that, under `MIR=true`, the PRO mirror is always unconditionally refreshed. Users who may not want the mirror to be refreshed (for example because they already refreshed it not too long ago) can set `MIR` to _false_ to use the existing mirror without refreshing it.

closes #60